### PR TITLE
fix: Set branch name for PRs

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -8136,6 +8136,14 @@ const pkg = __webpack_require__(731);
 
 const ACTION_UA = `${pkg.name}/${pkg.version}`;
 
+// Sets the required env info for Percy to work correctly
+function setPercyBranchBuildInfo(pullRequestNumber) {
+  let prBranch = github.context.payload.pull_request.head.ref;
+
+  core.exportVariable('PERCY_BRANCH', prBranch);
+  core.exportVariable('PERCY_PULL_REQUEST', pullRequestNumber);
+}
+
 (async () => {
   try {
     let flags = core.getInput('flags');
@@ -8160,7 +8168,7 @@ const ACTION_UA = `${pkg.name}/${pkg.version}`;
     }
 
     // Set the PR # (if available) and branch name
-    !!pullRequestNumber && core.exportVariable('PERCY_PULL_REQUEST', pullRequestNumber);
+    !!pullRequestNumber && setPercyBranchBuildInfo(pullRequestNumber);
 
     // Run the passed options with `percy snapshot` to create a Percy build
     await exec.exec(`"${npxPath}" percy snapshot ${outputDir} ${flags}`, [], execOptions);

--- a/dist/index.js
+++ b/dist/index.js
@@ -8136,14 +8136,6 @@ const pkg = __webpack_require__(731);
 
 const ACTION_UA = `${pkg.name}/${pkg.version}`;
 
-// Sets the required env info for Percy to work correctly
-function setPercyBranchBuildInfo(pullRequestNumber) {
-  let prBranch = github.context.payload.pull_request.head.ref;
-
-  core.exportVariable('PERCY_BRANCH', prBranch);
-  core.exportVariable('PERCY_PULL_REQUEST', pullRequestNumber);
-}
-
 (async () => {
   try {
     let flags = core.getInput('flags');
@@ -8152,7 +8144,6 @@ function setPercyBranchBuildInfo(pullRequestNumber) {
     let workingDir = core.getInput('working-directory');
     let outputDir = core.getInput('build-directory');
 
-    let pullRequestNumber = github.context.payload.number;
     let npxPath = await io.which('npx', true);
     let execOptions = { cwd: workingDir };
 
@@ -8168,7 +8159,10 @@ function setPercyBranchBuildInfo(pullRequestNumber) {
     }
 
     // Set the PR # (if available) and branch name
-    !!pullRequestNumber && setPercyBranchBuildInfo(pullRequestNumber);
+    if (github.context.payload.number) {
+      core.exportVariable('PERCY_PULL_REQUEST', github.context.payload.number);
+      core.exportVariable('PERCY_BRANCH', github.context.payload.pull_request.head.ref);
+    }
 
     // Run the passed options with `percy snapshot` to create a Percy build
     await exec.exec(`"${npxPath}" percy snapshot ${outputDir} ${flags}`, [], execOptions);

--- a/src/index.js
+++ b/src/index.js
@@ -6,14 +6,6 @@ const pkg = require('../package.json');
 
 const ACTION_UA = `${pkg.name}/${pkg.version}`;
 
-// Sets the required env info for Percy to work correctly
-function setPercyBranchBuildInfo(pullRequestNumber) {
-  let prBranch = github.context.payload.pull_request.head.ref;
-
-  core.exportVariable('PERCY_BRANCH', prBranch);
-  core.exportVariable('PERCY_PULL_REQUEST', pullRequestNumber);
-}
-
 (async () => {
   try {
     let flags = core.getInput('flags');
@@ -22,7 +14,6 @@ function setPercyBranchBuildInfo(pullRequestNumber) {
     let workingDir = core.getInput('working-directory');
     let outputDir = core.getInput('build-directory');
 
-    let pullRequestNumber = github.context.payload.number;
     let npxPath = await io.which('npx', true);
     let execOptions = { cwd: workingDir };
 
@@ -38,7 +29,10 @@ function setPercyBranchBuildInfo(pullRequestNumber) {
     }
 
     // Set the PR # (if available) and branch name
-    !!pullRequestNumber && setPercyBranchBuildInfo(pullRequestNumber);
+    if (github.context.payload.number) {
+      core.exportVariable('PERCY_PULL_REQUEST', github.context.payload.number);
+      core.exportVariable('PERCY_BRANCH', github.context.payload.pull_request.head.ref);
+    }
 
     // Run the passed options with `percy snapshot` to create a Percy build
     await exec.exec(`"${npxPath}" percy snapshot ${outputDir} ${flags}`, [], execOptions);

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,14 @@ const pkg = require('../package.json');
 
 const ACTION_UA = `${pkg.name}/${pkg.version}`;
 
+// Sets the required env info for Percy to work correctly
+function setPercyBranchBuildInfo(pullRequestNumber) {
+  let prBranch = github.context.payload.pull_request.head.ref;
+
+  core.exportVariable('PERCY_BRANCH', prBranch);
+  core.exportVariable('PERCY_PULL_REQUEST', pullRequestNumber);
+}
+
 (async () => {
   try {
     let flags = core.getInput('flags');
@@ -30,7 +38,7 @@ const ACTION_UA = `${pkg.name}/${pkg.version}`;
     }
 
     // Set the PR # (if available) and branch name
-    !!pullRequestNumber && core.exportVariable('PERCY_PULL_REQUEST', pullRequestNumber);
+    !!pullRequestNumber && setPercyBranchBuildInfo(pullRequestNumber);
 
     // Run the passed options with `percy snapshot` to create a Percy build
     await exec.exec(`"${npxPath}" percy snapshot ${outputDir} ${flags}`, [], execOptions);


### PR DESCRIPTION
Turns out the env var GitHub provides isn't good enough for all applications. So for PRs lets set the branch name from the webhook playload. See: https://github.com/percy/example-percy-jekyll/pull/12